### PR TITLE
Automatically send progress event when rendered with display_submit=False

### DIFF
--- a/mentoring/mentoring.py
+++ b/mentoring/mentoring.py
@@ -98,7 +98,12 @@ class MentoringBlock(XBlock, StepParentMixin):
         scope=Scope.content,
         enforce_type=True
     )
-    display_submit = Boolean(help="Allow to submit current block?", default=True, scope=Scope.content)
+    display_submit = Boolean(
+        help="Allow submission of the current block?",
+        default=True,
+        scope=Scope.content,
+        enforce_type=True
+    )
     xml_content = String(help="XML content", default=default_xml_content, scope=Scope.content)
 
     # Settings
@@ -212,6 +217,9 @@ class MentoringBlock(XBlock, StepParentMixin):
         fragment.add_resource(loader.load_unicode('templates/html/mentoring_grade.html'), "text/html")
 
         fragment.initialize_js('MentoringBlock')
+
+        if not self.display_submit:
+            self.runtime.publish(self, 'progress', {})
 
         return fragment
 

--- a/mentoring/tests/integration/test_mentoring.py
+++ b/mentoring/tests/integration/test_mentoring.py
@@ -1,0 +1,9 @@
+from selenium.common.exceptions import NoSuchElementException
+from .base_test import MentoringBaseTest
+
+
+class MentoringTest(MentoringBaseTest):
+    def test_display_submit_false_does_not_display_submit(self):
+        mentoring = self.go_to_page('No Display Submit')
+        with self.assertRaises(NoSuchElementException):
+            mentoring.find_element_by_css_selector('.submit input.input-main')

--- a/mentoring/tests/integration/xml/no_display_submit.xml
+++ b/mentoring/tests/integration/xml/no_display_submit.xml
@@ -1,0 +1,5 @@
+<vertical_demo>
+    <mentoring url_name="answer_blank_read_only" enforce_dependency="false" display_submit="false">
+        <answer name="answer_blank"/>
+    </mentoring>
+</vertical_demo>

--- a/mentoring/tests/unit/test_mentoring.py
+++ b/mentoring/tests/unit/test_mentoring.py
@@ -1,0 +1,30 @@
+import unittest
+from mock import MagicMock, Mock, patch
+from xblock.field_data import DictFieldData
+from mentoring import MentoringBlock
+
+
+class TestMentoringBlock(unittest.TestCase):
+    def test_sends_progress_event_when_rendered_student_view_with_display_submit_false(self):
+        block = MentoringBlock(MagicMock(), DictFieldData({
+            'display_submit': False
+        }), Mock())
+
+        with patch.object(block, 'runtime') as patched_runtime:
+            patched_runtime.publish = Mock()
+
+            block.student_view(context={})
+
+            patched_runtime.publish.assert_called_once_with(block, 'progress', {})
+
+    def test_does_not_send_progress_event_when_rendered_student_view_with_display_submit_true(self):
+        block = MentoringBlock(MagicMock(), DictFieldData({
+            'display_submit': True
+        }), Mock())
+
+        with patch.object(block, 'runtime') as patched_runtime:
+            patched_runtime.publish = Mock()
+
+            block.student_view(context={})
+
+            self.assertFalse(patched_runtime.publish.called)


### PR DESCRIPTION
@bradenmacdonald please note I recreated `real-children` branch - we might still need it to port stuff from edx-solutions branches.

Also, I still got 1 error and 3 failures in my local installation, so any thought on how it works in travis and your environment are welcome (e.g. which versions of xblock-sdk and XBlock are used)
