### PR TITLE
Real children setup (OC-513)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ install:
     - "pip install -r $VIRTUAL_ENV/src/xblock-sdk/requirements.txt"
     - "pip install -r $VIRTUAL_ENV/src/xblock-sdk/test-requirements.txt"
     - "pip install -r requirements.txt"
+    - "pip uninstall -y xblock-mentoring && python setup.py sdist && pip install dist/xblock-mentoring-0.1.tar.gz"
 script: python run_tests.py --with-coverage --cover-package=mentoring && pep8 mentoring --max-line-length=120 && pylint mentoring --disable=all --enable=function-redefined,undefined-variable,unused-variable
 notifications:
   email: false

--- a/setup.py
+++ b/setup.py
@@ -74,5 +74,5 @@ setup(
     entry_points={
         'xblock.v1': BLOCKS,
     },
-    package_data=package_data("mentoring", ["static", "templates", "public"]),
+    package_data=package_data("mentoring", ["components", "templates", "public", "migrations"]),
 )


### PR DESCRIPTION
@bradenmacdonald @e-kolpakov Without this installing the pip package instead of the raw mentoring repo results in `Error: No module named components.answer` when starting the LMS/CMS.

I have also updated the Travis config to allow to detect this type of issue in the test builds.
