### PR TITLE
Redesigned tooltips for LMS theme.

### DIFF
--- a/mentoring/public/js/mentoring.js
+++ b/mentoring/public/js/mentoring.js
@@ -52,6 +52,7 @@ function MentoringBlock(runtime, element) {
 
         if (!clickedInside(item_feedback_selector, item_feedback_parent_selector)) {
             $(item_feedback_selector).not(':hidden').hide();
+            $('.choice-tips-container').removeClass('with-tips');
         }
     });
 

--- a/mentoring/public/js/questionnaire.js
+++ b/mentoring/public/js/questionnaire.js
@@ -3,7 +3,9 @@
 function MessageView(element, mentoring) {
     return {
         messageDOM: $('.feedback', element),
+        allChoicesDOM: $('.choice', element),
         allPopupsDOM: $('.choice-tips, .feedback', element),
+        allPopupContainersDOM: $('.choice-tips-container', element),
         allResultsDOM: $('.choice-result', element),
         clearPopupEvents: function() {
             this.allPopupsDOM.hide();
@@ -28,6 +30,11 @@ function MessageView(element, mentoring) {
                 popupDOM.css('height', '');
             }
 
+            var container = popupDOM.parent('.choice-tips-container');
+            if (container.length) {
+                this.allPopupContainersDOM.addClass('with-tips').removeClass('active');
+                container.addClass('active');
+            }
             popupDOM.show();
 
             mentoring.publish_event({
@@ -53,6 +60,8 @@ function MessageView(element, mentoring) {
             }
         },
         clearResult: function() {
+            this.allPopupContainersDOM.removeClass('with-tips active');
+            this.allChoicesDOM.removeClass('correct incorrect');
             this.allPopupsDOM.html('').hide();
             this.allResultsDOM.removeClass(
                 'checkmark-incorrect icon-exclamation fa-exclamation checkmark-correct icon-ok fa-check'
@@ -85,6 +94,7 @@ function MCQBlock(runtime, element) {
             if (this.mode === 'assessment')
                 return;
 
+
             mentoring = this.mentoring;
 
             var messageView = MessageView(element, mentoring);
@@ -99,14 +109,17 @@ function MCQBlock(runtime, element) {
                 var choiceTipsCloseDOM;
 
                 if (result.status === "correct" && choiceInputDOM.val() === result.submission) {
+                    choiceDOM.addClass('correct');
                     choiceResultDOM.addClass('checkmark-correct icon-ok fa-check');
                 }
                 else if (choiceInputDOM.val() === result.submission || _.isNull(result.submission)) {
+                    choiceDOM.addClass('incorrect');
                     choiceResultDOM.addClass('checkmark-incorrect icon-exclamation fa-exclamation');
                 }
 
                 if (result.tips && choiceInputDOM.val() === result.submission) {
                     mentoring.setContent(choiceTipsDOM, result.tips);
+                    messageView.showMessage(choiceTipsDOM);
                 }
 
                 choiceTipsCloseDOM = $('.close', choiceTipsDOM);
@@ -120,9 +133,6 @@ function MCQBlock(runtime, element) {
             if (_.isNull(result.submission)) {
                 messageView.showMessage('<div class="message-content">You have not provided an answer.</div>' +
                                         '<div class="close icon-remove-sign fa-times-circle"></div>');
-            }
-            else if (result.tips) {
-                messageView.showMessage(result.tips);
             }
         },
 
@@ -189,8 +199,10 @@ function MRQBlock(runtime, element) {
                 if (!hide_results &&
                     (result.completed || choiceInputDOM.prop('checked') || options.max_attempts <= 0)) {
                     if (choice.completed) {
+                        choiceDOM.addClass('correct');
                         choiceResultDOM.addClass('checkmark-correct icon-ok fa-check');
                     } else if (!choice.completed) {
+                        choiceDOM.addClass('incorrect');
                         choiceResultDOM.addClass('checkmark-incorrect icon-exclamation fa-exclamation');
                     }
 

--- a/mentoring/public/themes/lms.css
+++ b/mentoring/public/themes/lms.css
@@ -1,5 +1,19 @@
+.themed-xblock.mentoring .questionnaire .choice-result {
+    display: table-cell;
+}
+
+.themed-xblock.mentoring .choice-result::before {
+    content: "";
+    display: block;
+    width: 36px;
+}
+
 .themed-xblock.mentoring .checkmark-incorrect {
     color: #c1373f;
+}
+
+.themed-xblock.mentoring .checkmark-correct::before {
+    content: "\f00c";
 }
 
 .themed-xblock.mentoring .checkmark-incorrect::before {
@@ -15,4 +29,78 @@
 div.course-wrapper section.course-content .themed-xblock.mentoring p:empty {
     display: block;
     margin-bottom: 1.41575em;
+}
+
+.themed-xblock.mentoring .choices-list {
+    display: table;
+    width: 100%;
+    border-spacing: 0;
+}
+
+.themed-xblock.mentoring .choice-label {
+    display: table-cell;
+    vertical-align: middle;
+    width: 100%;
+    padding-bottom: 10px;
+    padding-top: 2px;
+}
+
+.themed-xblock.mentoring .choice-label span.low {
+    line-height: inherit;
+}
+
+.themed-xblock.mentoring .choice-result,
+.themed-xblock.mentoring .choice-label,
+.themed-xblock.mentoring .choice-tips-container {
+    vertical-align: top;
+}
+
+.themed-xblock.mentoring .choice-tips {
+    position: relative;
+}
+
+.themed-xblock.mentoring .questionnaire .choice {
+    display: table-row;
+}
+
+.themed-xblock.mentoring .questionnaire .feedback {
+    min-height: 100%;
+    border-left: 2px solid #ddd;
+}
+
+.themed-xblock.mentoring .questionnaire .choice-tips,
+.themed-xblock.mentoring .questionnaire .feedback {
+    color: #3c3c3c;
+    background: transparent;
+    font-family: inherit;
+    font-size: inherit;
+    opacity: 1;
+    padding: 0 20px;
+}
+
+.themed-xblock.mentoring .questionnaire .choice-tips-container {
+    display: table-cell;
+}
+
+
+.themed-xblock.mentoring .questionnaire .choice-tips p,
+.themed-xblock.mentoring .questionnaire .feedback p {
+    color: #3c3c3c;
+}
+
+.themed-xblock.mentoring .questionnaire .choice-tips .close,
+.themed-xblock.mentoring .questionnaire .feedback .close {
+    display: none;
+}
+
+.themed-xblock.mentoring .choice .choice-tips-container.with-tips {
+    border-left: 2px solid #ddd;
+}
+
+.themed-xblock.mentoring .choice.correct .choice-tips-container.active {
+    border-color: #629b2b;
+}
+
+.themed-xblock.mentoring .choice.incorrect .choice-tips-container.active {
+    border-color: #c1373f;
 }

--- a/mentoring/templates/html/mcqblock.html
+++ b/mentoring/templates/html/mcqblock.html
@@ -11,7 +11,9 @@
         <input class="choice-selector" type="radio" name="{{ self.name }}" value="{{ choice.value }}"{% if self.student_choice == choice.value %} checked{% endif %} />
           <span class="choice-text">{{ choice.content|safe }}</span>
       </label>
-      <div class="choice-tips"></div>
+      <div class="choice-tips-container">
+        <div class="choice-tips"></div>
+      </div>
     </div>
     {% endfor %}
     <div class="feedback"></div>

--- a/mentoring/templates/html/mrqblock.html
+++ b/mentoring/templates/html/mrqblock.html
@@ -13,7 +13,9 @@
                {% if choice.value in self.student_choices %} checked{% endif %} />
         <span class="choice-text">{{ choice.content|safe }}</span>
       </label>
-      <div class="choice-tips"></div>
+      <div class="choice-tips-container">
+        <div class="choice-tips"></div>
+      </div>
     </div>
     {% endfor %}
     <div class="feedback"></div>

--- a/mentoring/templates/html/ratingblock.html
+++ b/mentoring/templates/html/ratingblock.html
@@ -4,40 +4,36 @@
     <p>{{ self.question }}</p>
   </legend>
   <div class="choices-list">
-    <div class="choice">
-      <div class="choice-result fa icon-2x"></div>
-      <label><input class="choice-selector" type="radio" name="{{ self.name }}" value="1"{% if self.student_choice == '1' %} checked{% endif %} />1</label>
-      <span class="low"> - {{ self.low }}</span>
-      <div class="choice-tips"></div>
-    </div>
-    <div class="choice">
-      <div class="choice-result fa icon-2x"></div>
-      <label><input class="choice-selector" type="radio" name="{{ self.name }}" value="2"{% if self.student_choice == '2' %} checked{% endif %} />2</label>
-      <div class="choice-tips"></div>
-    </div>
-    <div class="choice">
-      <div class="choice-result fa icon-2x"></div>
-      <label><input class="choice-selector" type="radio" name="{{ self.name }}" value="3"{% if self.student_choice == '3' %} checked{% endif %} />3</label>
-      <div class="choice-tips"></div>
-    </div>
-    <div class="choice">
-      <div class="choice-result fa icon-2x"></div>
-      <label><input class="choice-selector" type="radio" name="{{ self.name }}" value="4"{% if self.student_choice == '4' %} checked{% endif %} />4</label>
-      <div class="choice-tips"></div>
-    </div>
-    <div class="choice">
-      <div class="choice-result fa icon-2x"></div>
-      <label><input class="choice-selector" type="radio" name="{{ self.name }}" value="5"{% if self.student_choice == '5' %} checked{% endif %} />5</label>
-      <span class="low"> - {{ self.high }}</span>
-      <div class="choice-tips"></div>
-    </div>
+    {% for value in '12345' %}
+      <div class="choice">
+        <div class="choice-result fa icon-2x"></div>
+        <label class="choice-label">
+          <input class="choice-selector" type="radio" name="{{ self.name }}" value="{{ value }}"
+                 {% if self.student_choice == value %}checked{% endif %} />
+          {{ value }}
+          {% if forloop.first %}
+            <span class="low">- {{ self.low }}</span>
+          {% endif %}
+          {% if forloop.last %}
+            <span class="low">- {{ self.high }}</span>
+          {% endif %}
+        </label>
+        <div class="choice-tips-container">
+          <div class="choice-tips"></div>
+        </div>
+      </div>
+    {% endfor %}
     {% for choice in custom_choices %}
     <div class="choice">
       <div class="choice-result fa icon-2x"></div>
-      <label><input type="radio" name="{{ self.name }}" value="{{ choice.value }}"{% if self.student_choice == '{{ choice.value }}' %} checked{% endif %} />
+      <label class="choice-label">
+        <input class="choice-selector" type="radio" name="{{ self.name }}" value="{{ choice.value }}"
+               {% if self.student_choice == '{{ choice.value }}' %} checked{% endif %} />
           <span class="choice-text">{{ choice.content|safe }}</span>
       </label>
-      <div class="choice-tips"></div>
+      <div class="choice-tips-container">
+        <div class="choice-tips"></div>
+      </div>
     </div>
     {% endfor %}
     <div class="feedback"></div>


### PR DESCRIPTION
This changes the look of MCQ/MRQ tooltips to better fit into the LMS design, as per http://tasks.opencraft.com/browse/OC-559.

The main changes are:
- Instead of a popup appearing on top of the text, add a thin separator line on the right hand side of the choices, and the feedback content to the right of that separator
- Show visually which choices the feedback relates to, by coloring the separator line next to the choice the feedback is about, and aligning the feedback content vertically to the selected choice.
- Existing behavior (clicking on the checkmark/cross mark to display feedback, etc.) is unchanged

_Provided Mockup_

![screen shot 2015-03-26 at 14 12 06](https://cloud.githubusercontent.com/assets/32585/6841251/2173d7f8-d3c2-11e4-9cee-178a0f74b03d.png)

_How to Test_
1. Go to http://sandbox.opencraft.com/
2. Sign in with the `staff@example.com`/`edx` account.
3. Go to "TST-MENTORING-2 Mentoring v2 Test Course"
4. Navigate to "Courseware -> Week 1 -> Mentoring v2". The section contains 3 units with three different types of mentoring questions (MCQ, Rating MCQ, and MRQ)
5. Submit answers to each question and observe the tips that are displayed on the right side after submitting. Try different answers for each question.
6. Confirm that:
   - MCQ questions display the tip aligned with the selected question after submitting. The line next to the selected questions should be red or green, depending on whether the selected choice is the correct answer. Clicking outside the question or chosing another answer clears the tip.
   - MRQ questions display the general feedback after submitting. Clicking on the result icons on the left side of the choice shows tip for the specific choice. Clicking outside the question or chosing another answer clears the tip.
